### PR TITLE
Update linting and testing infrastructure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,5 @@
-version: 2
 jobs:
-  build:
+  setup:
     docker:
       - image: circleci/ruby:2.7.0
         environment:
@@ -11,17 +10,29 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - renderful-v1-{{ checksum "Gemfile.lock" }}
+            - renderful-v1-{{ .Branch }}
             - renderful-v1-
       - run:
           name: Bundle Install
           command: bundle check || bundle install
       - save_cache:
-          key: renderful-v1-{{ checksum "Gemfile.lock" }}
+          key: renderful-v1-{{ .Branch }}
           paths:
             - vendor/bundle
+
+  test:
+    docker:
+      - image: circleci/ruby:2.7.0
+        environment:
+          BUNDLE_PATH: vendor/bundle
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - renderful-v1-{{ .Branch }}
+            - renderful-v1-
       - run:
-          name: Run rspec in parallel
+          name: Run RSpec
           command: |
             bundle exec rspec --profile 10 \
               --format RspecJunitFormatter \
@@ -30,3 +41,30 @@ jobs:
               $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
       - store_test_results:
           path: test_results
+
+  lint:
+    docker:
+      - image: circleci/ruby:2.7.0
+        environment:
+          BUNDLE_PATH: vendor/bundle
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - renderful-v1-{{ .Branch }}
+            - renderful-v1-
+      - run:
+          name: Run RuboCop
+          command: bundle exec rubocop
+
+workflows:
+  version: 2
+  test-and-lint:
+    jobs:
+      - setup
+      - test:
+          requires:
+            - setup
+      - lint:
+          requires:
+            - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.6.2
+      - image: circleci/ruby:2.7.0
         environment:
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,5 +1,0 @@
-fail_on_violations: true
-
-rubocop:
-  config_file: .rubocop.yml
-  version: 0.64.0

--- a/.rubocop-https---relaxed-ruby-style-rubocop-yml
+++ b/.rubocop-https---relaxed-ruby-style-rubocop-yml
@@ -1,5 +1,5 @@
 # Relaxed.Ruby.Style
-## Version 2.2
+## Version 2.4
 
 Style/Alias:
   Enabled: false
@@ -65,6 +65,10 @@ Style/NegatedWhile:
   Enabled: false
   StyleGuide: https://relaxed.ruby.style/#stylenegatedwhile
 
+Style/NumericPredicate:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#stylenumericpredicate
+
 Style/ParallelAssignment:
   Enabled: false
   StyleGuide: https://relaxed.ruby.style/#styleparallelassignment
@@ -120,6 +124,10 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   Enabled: false
   StyleGuide: https://relaxed.ruby.style/#styletrailingcommainhashliteral
+
+Style/SymbolArray:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylesymbolarray
 
 Style/WhileUntilModifier:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,22 +1,8 @@
 inherit_from:
   - https://relaxed.ruby.style/rubocop.yml
 
-require: rubocop-rspec
+AllCops:
+  TargetRubyVersion: 2.4
 
 Metrics/BlockLength:
-  Enabled: false
-
-Layout/IndentHash:
-  EnforcedStyle: consistent
-
-RSpec/ExampleLength:
-  Enabled: false
-
-Layout/ClosingParenthesisIndentation:
-  Enabled: false
-
-Layout/FirstParameterIndentation:
-  EnforcedStyle: consistent
-
-RSpec/NestedGroups:
   Enabled: false

--- a/lib/renderful/cache_invalidator.rb
+++ b/lib/renderful/cache_invalidator.rb
@@ -14,9 +14,9 @@ module Renderful
       params = body.is_a?(String) ? JSON.parse(body) : body
 
       client.cache.delete(client.cache_key_for(
-        content_type_id: params['sys']['contentType']['sys']['id'],
-        entry_id: params['sys']['id'],
-      ))
+                            content_type_id: params['sys']['contentType']['sys']['id'],
+                            entry_id: params['sys']['id'],
+                          ))
 
       client.contentful.entries(links_to_entry: params['sys']['id']).each do |linking_entry|
         client.cache.delete(client.cache_key_for(linking_entry))

--- a/renderful.gemspec
+++ b/renderful.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'redis', '~> 4.1'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.4.1'
-  # These are locked because we need to use Hound's versions
-  spec.add_development_dependency 'rubocop', '0.64.0'
-  spec.add_development_dependency 'rubocop-rspec', '1.32.0'
+  spec.add_development_dependency 'rubocop', '~> 0.79.0'
+  spec.add_development_dependency 'rubocop-rspec', '~> 1.37'
 end

--- a/renderful.gemspec
+++ b/renderful.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'contentful', '~> 2.11'
   spec.add_dependency 'rails', '~> 5.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.17'
+  spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'redis', '~> 4.1'
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/spec/renderful/renderer/rails_spec.rb
+++ b/spec/renderful/renderer/rails_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Renderful::Renderer::Rails do
 
   let(:rails_renderer) { instance_spy('ActionController::Renderer') }
 
-  before(:all) do # rubocop:disable RSpec/BeforeAfterAll
+  before(:all) do
     TestComponentRenderer = Class.new(described_class) do
       def locals
         { test_local: 'local_value' }
@@ -37,30 +37,30 @@ RSpec.describe Renderful::Renderer::Rails do
       renderer.render
 
       expect(rails_renderer).to have_received(:render).with(a_hash_including(
-        partial: 'renderful/test_component',
-      ))
+                                                              partial: 'renderful/test_component',
+                                                            ))
     end
 
     it 'passes locals to the view' do
       renderer.render
 
       expect(rails_renderer).to have_received(:render).with(a_hash_including(
-        locals: a_hash_including(
-          test_local: 'local_value',
-        ),
-      ))
+                                                              locals: a_hash_including(
+                                                                test_local: 'local_value',
+                                                              ),
+                                                            ))
     end
 
     it 'passes the entry, renderer and client to the view' do
       renderer.render
 
       expect(rails_renderer).to have_received(:render).with(a_hash_including(
-        locals: a_hash_including(
-          entry: entry,
-          renderer: renderer,
-          client: client,
-        ),
-      ))
+                                                              locals: a_hash_including(
+                                                                entry: entry,
+                                                                renderer: renderer,
+                                                                client: client,
+                                                              ),
+                                                            ))
     end
   end
 end


### PR DESCRIPTION
Updates to Ruby 2.7.0 and moves RuboCop execution to CircleCI rather than delegating it to [Hound](https://houndci.com/).

Services such as Hound are problematic because they run their own versions of the linters you use, which is bound to cause discrepancies and/or force you to stay on an older version of a linter.

With CircleCI, we can simply run RuboCop like we do it locally.