### PR TITLE
Raise error when entry not found

### DIFF
--- a/lib/renderful.rb
+++ b/lib/renderful.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'renderful/error/base'
+require 'renderful/error/entry_not_found_error'
 require 'renderful/error/no_component_error'
 require 'renderful/cache/base'
 require 'renderful/cache/redis'

--- a/lib/renderful/error/entry_not_found_error.rb
+++ b/lib/renderful/error/entry_not_found_error.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Renderful
+  module Error
+    class EntryNotFoundError < Base
+      attr_reader :entry_id
+
+      def initialize(entry_id, *args)
+        @entry_id = entry_id
+
+        super "Cannot find entry #{@entry_id}", *args
+      end
+    end
+  end
+end

--- a/lib/renderful/provider/contentful.rb
+++ b/lib/renderful/provider/contentful.rb
@@ -14,7 +14,10 @@ module Renderful
       end
 
       def find_entry(entry_id)
-        wrap_entry(contentful.entry(entry_id))
+        entry = contentful.entry(entry_id)
+        raise Error::EntryNotFoundError, entry_id unless entry
+
+        wrap_entry(entry)
       end
 
       def cache_keys_to_invalidate(webhook_body)

--- a/lib/renderful/provider/prismic.rb
+++ b/lib/renderful/provider/prismic.rb
@@ -14,7 +14,10 @@ module Renderful
       end
 
       def find_entry(entry_id)
-        wrap_entry(prismic.getByID(entry_id))
+        entry = prismic.getByID(entry_id)
+        raise Error::EntryNotFoundError, entry_id unless entry
+
+        wrap_entry(entry)
       end
 
       def cache_keys_to_invalidate(_webhook_body)

--- a/lib/renderful/version.rb
+++ b/lib/renderful/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Renderful
-  VERSION = "0.2.0"
+  VERSION = '0.3.0'
 end

--- a/spec/renderful/provider/contentful_spec.rb
+++ b/spec/renderful/provider/contentful_spec.rb
@@ -49,6 +49,18 @@ RSpec.describe Renderful::Provider::Contentful do
 
       expect(content_entry.provider).to eq(subject)
     end
+
+    context 'when entry not found' do
+      it 'raises an error' do
+        allow(contentful).to receive(:entry)
+          .with(entry_id)
+          .and_return(nil)
+
+        expect do
+          subject.find_entry(entry_id)
+        end.to raise_error(Renderful::Error::EntryNotFoundError)
+      end
+    end
   end
 
   describe '#cache_keys_to_invalidate' do

--- a/spec/renderful/provider/prismic_spec.rb
+++ b/spec/renderful/provider/prismic_spec.rb
@@ -49,6 +49,18 @@ RSpec.describe Renderful::Provider::Prismic do
 
       expect(content_entry.provider).to eq(subject)
     end
+
+    context 'when entry not found' do
+      it 'raises an error' do
+        allow(prismic).to receive(:getByID)
+          .with(entry_id)
+          .and_return(nil)
+
+        expect do
+          subject.find_entry(entry_id)
+        end.to raise_error(Renderful::Error::EntryNotFoundError)
+      end
+    end
   end
 
   describe '#cache_keys_to_invalidate' do


### PR DESCRIPTION
This PR makes providers raise an `EntryNotFoundError` when entry is not found to avoid raising `NoMethodError: undefined method 'id' for nil:NilClass` when trying to wrap a `nil` entry.